### PR TITLE
Home Assistant Autodiscovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /obj
 /.vs/
 /wiser2mqtt.csproj.user
+/.vscode

--- a/MqttHelper.cs
+++ b/MqttHelper.cs
@@ -34,9 +34,9 @@ namespace Wiser2Mqtt
             await _mqttClient.ConnectAsync(options, CancellationToken.None);
 
         }
-        public async Task PublishMessage(string topic, string payload)
+        public async Task PublishMessage(string topic, string payload, bool retain = false)
         {
-            await _mqttClient.PublishAsync(topic, payload);
+            await _mqttClient.PublishAsync(topic, payload, retain);
 
         }
     }

--- a/MqttHelper.cs
+++ b/MqttHelper.cs
@@ -22,9 +22,13 @@ namespace Wiser2Mqtt
         }
         public async Task Initialize()
         {
-            var options = new MqttClientOptionsBuilder()
-                .WithTcpServer(_options.Host, _options.Port) // Port is optional
-            .Build();
+            var builder = new MqttClientOptionsBuilder()
+                .WithTcpServer(_options.Host, _options.Port);
+            if (!string.IsNullOrEmpty(_options.Username))
+            {
+                builder = builder.WithCredentials(_options.Username, _options.Password);
+            }
+            var options = builder.Build();
             var factory = new MqttFactory();
             _mqttClient = factory.CreateMqttClient();
             await _mqttClient.ConnectAsync(options, CancellationToken.None);

--- a/MqttOptions.cs
+++ b/MqttOptions.cs
@@ -11,6 +11,8 @@ namespace Wiser2Mqtt
         public const string ConfigKey = "Mqtt";
         public string Host { get; set; }
         public int Port { get; set; }
-
+        public string Username { get; set; }
+        public string Password { get; set; }
+        public bool HassAutoDiscovery { get; set; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ Example configuration :
 {
   "Mqtt": {
     "Host": "10.0.0.10",
-    "Port": 1883
+    "Port": 1883,
+    "Username": "user",
+    "Password": "verysecret",
+    "HassAutoDiscovery": true
   },
   "Wiser": {
     "Host": "10.0.0.11",

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,7 +1,10 @@
 {
   "Mqtt": {
     "Host": "10.0.0.10",
-    "Port": 1883
+    "Port": 1883,
+    "Username": "user",
+    "Password": "verysecret",
+    "HassAutoDiscovery": true
   },
   "Wiser": {
     "Host": "10.0.0.11",


### PR DESCRIPTION
Hi there.

This PR adds option for setting auth info for MQTT broker (if no username is set, auth will not be set, so setups without auth should still work).

And more importantly, this PR also adds HASS auto discovery for creating a device in HA with sensors attached to it. There are many more sensors that could be added, but for now I just added those I find most useful:
![image](https://user-images.githubusercontent.com/2242329/158056409-3ff4a9a8-9a94-4718-84b5-3057c8c7f3ec.png)

The accumulated power sensor has the required attributes set, so it's ready to be added in HA's energy dashboard without further configuration or template sensors.

I added the new options in the sample appsettings.json as well as in the README.MD